### PR TITLE
Bump alpine from 3.14.3 to 3.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --no-cache add make git gcc libc-dev curl && make build
 # -----------------------------------------------------------------------------
 # Build the final Docker image
 
-FROM alpine:3.14.3
+FROM alpine:3.16.0
 ARG KUBECTL_VERSION="v1.21.2"
 
 COPY --from=build /k9s/execs/k9s /bin/k9s


### PR DESCRIPTION
Bumps alpine from 3.14.3 to 3.16.0.

---
updated-dependencies:
- dependency-name: alpine
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>